### PR TITLE
fix age and weight labels for sort in coin control

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -837,13 +837,13 @@ void CoinControlDialog::updateView()
             nInputSum    += nInputSize;
 			
 			// List Mode Weight
-            itemOutput->setText(COLUMN_WEIGHT, QString::number(nTxWeight, 'f',0));
+            itemOutput->setText(COLUMN_WEIGHT, strPad(QString::number((uint64_t)nTxWeight),8," "));
 			
 			// Age
 			uint64_t nAge = GetTime() - out.tx->GetTxTime();
 			double age  = (double)nAge/60/60/24;
 			itemOutput->setText(COLUMN_AGE, QString::number(age, 'f', 2));
-			itemOutput->setText(COLUMN_AGE_int64_t, strPad(QString::number(age), 15, " "));
+			itemOutput->setText(COLUMN_AGE_int64_t, strPad(QString::number(nAge), 15, " "));
 			
 			// Potential Stake
 			double nPotentialStake = 20 / (1 + (nBestHeight / YEARLY_BLOCKCOUNT));


### PR DESCRIPTION
nAge and calculated by not used, should be used in hidden int column
weight is being flattened to a float, breaking sort. as string padded int will sort as expected