### PR TITLE
.gitignore compiled binary.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ src/build.h
 *.qm
 Makefile
 pinkcoin-qt
+Pinkcoin-Qt
 #resources cpp
 qrc_*.cpp
 #qt creator


### PR DESCRIPTION
The capitalization of the ignored file was different
than the actual file so on systems with case sensitive filesystems
(!OSX) it does not actually ignore it.